### PR TITLE
Add checks to ensure target is not null (fixes some crashes)

### DIFF
--- a/src/main/java/com/toast/apocalypse/common/entity/living/Destroyer.java
+++ b/src/main/java/com/toast/apocalypse/common/entity/living/Destroyer.java
@@ -220,6 +220,7 @@ public class Destroyer extends AbstractFullMoonGhast {
         @Override
         public void tick() {
             LivingEntity target = destroyer.getTarget();
+            if (target == null) return;
 
             if (destroyer.withinFiringRange(target.position()) && destroyer.hasLineOfSight(target)) {
                 Level level = destroyer.level();

--- a/src/main/java/com/toast/apocalypse/common/entity/living/Ghost.java
+++ b/src/main/java/com/toast/apocalypse/common/entity/living/Ghost.java
@@ -496,6 +496,8 @@ public class Ghost extends FlyingMob implements Enemy, IFullMoonMob {
         @Override
         public void tick() {
             LivingEntity target = ghost.getTarget();
+            if (target == null) return;
+
             double distance = ghost.distanceToSqr(target);
 
             if (!ghost.isManeuvering() && ghost.tickCount % 20 == 0) {

--- a/src/main/java/com/toast/apocalypse/common/entity/living/Seeker.java
+++ b/src/main/java/com/toast/apocalypse/common/entity/living/Seeker.java
@@ -212,6 +212,7 @@ public class Seeker extends AbstractFullMoonGhast {
         @Override
         public void tick() {
             LivingEntity target = seeker.getTarget();
+            if (target == null) return;
 
             if (seeker.horizontalDistanceToSqr(target) < 4096.0D) {
                 Level level = seeker.level();


### PR DESCRIPTION
I have had some crashes due to some functions not checking the target isn't null, this should fix them (I looked at all occurrences of getTarget())

Example Crash Log:
```
// Why is it breaking :(

Time: 2025-03-27 23:17:55
Description: Ticking entity

java.lang.NullPointerException: Cannot invoke "net.minecraft.world.entity.Entity.m_20182_()" because "entity" is null
	at com.toast.apocalypse.common.entity.living.AbstractFullMoonGhast.horizontalDistanceToSqr(AbstractFullMoonGhast.java:43) ~[Apocalypse-Rebooted-1.20.1-2.5.8-r-all.jar%23336!/:1.20.1-2.5.8-r] {re:classloading}
	at com.toast.apocalypse.common.entity.living.Seeker$FireballAttackGoal.m_8037_(Seeker.java:216) ~[Apocalypse-Rebooted-1.20.1-2.5.8-r-all.jar%23336!/:1.20.1-2.5.8-r] {re:classloading}
	at net.minecraft.world.entity.ai.goal.WrappedGoal.m_8037_(WrappedGoal.java:65) ~[server-1.20.1-20230612.114412-srg.jar%23543!/:?] {re:classloading,pl:connector_pre_launch:A}
	at net.minecraft.world.entity.ai.goal.GoalSelector.m_186081_(GoalSelector.java:120) ~[server-1.20.1-20230612.114412-srg.jar%23543!/:?] {re:mixin,pl:accesstransformer:B,pl:connector_pre
```